### PR TITLE
Remove redundant quotes from check_dimension

### DIFF
--- a/src/screen.sh
+++ b/src/screen.sh
@@ -65,7 +65,7 @@ dimension_msg() {
 #   1 - the dimension is not a multiple of 8
 check_dimension() {
     # the dimension will be a multiple of 8 if the remainder is 0
-    [ "$(("$1" % 8))" = '0' ]
+    [ "$(($1 % 8))" = '0' ]
 }
 
 # description:


### PR DESCRIPTION
The `check_dimension` function contains redundant quotes which cause: `arithmetic expression: expecting primary:`
when executed under modern `bash` versions, `dash`, etc. as bash attempts to perform the modulo operation on a string. This change removes the quotes, allowing the function to return correctly.